### PR TITLE
Sourcing images from Swift S3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+docker-compose.override.yml
 jai-1_1_2_01-lib-linux-i586.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-docker-compose.override.yml
+jai-1_1_2_01-lib-linux-i586.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-config.json
+docker-compose.override.yml

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "cihm-cookie-authorizer"]
-	path = cihm-cookie-authorizer
-	url = git@github.com:crkn-rcdr/cihm-cookie-authorizer.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "cihm-cookie-authorizer"]
+	path = cihm-cookie-authorizer
+	url = git@github.com:crkn-rcdr/cihm-cookie-authorizer.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,10 @@ RUN apk add --update curl openjpeg-tools ruby msttcorefonts-installer fontconfig
   && update-ms-fonts \
   && fc-cache -f
 
-# Needed to make local copy from http://www.oracle.com/technetwork/java/javasebusiness/downloads/java-archive-downloads-java-client-419417.html
-RUN curl -OL "http://pinto.c7a.ca/deploy/jai-1_1_2_01-lib-linux-i586.tar.gz" \
-  && tar -xvzpf jai-1_1_2_01-lib-linux-i586.tar.gz
+# You need to download a local copy of the Java Advanced Imaging API 1.1.2_01
+# http://www.oracle.com/technetwork/java/javasebusiness/downloads/java-archive-downloads-java-client-419417.html
+COPY jai-1_1_2_01-lib-linux-i586.tar.gz /tmp
+RUN tar -xvzpf jai-1_1_2_01-lib-linux-i586.tar.gz
 
 ENV JAIHOME=/tmp/jai-1_1_2_01/lib \
   CLASSPATH=$JAIHOME/jai_core.jar:$JAIHOME/jai_codec.jar:$JAIHOME/mlibwrapper_jai.jar:$CLASSPATH \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # this file is an edited version of https://github.com/kaij/cantaloupe/blob/docker-deploy/docker/Dockerfile
 
-FROM openjdk:8u181-alpine
+FROM openjdk:8u191-alpine
 
-ENV VERSION 4.1.2
+ENV VERSION 4.1.3
 
 WORKDIR /tmp
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,11 @@
 
 FROM openjdk:8u181-alpine
 
-ENV VERSION 4.0.2
-EXPOSE 8182
+ENV VERSION 4.1.2
 
 WORKDIR /tmp
 
-RUN  apk add --update curl openjpeg-tools ruby msttcorefonts-installer fontconfig \
+RUN apk add --update curl openjpeg-tools ruby msttcorefonts-installer fontconfig \
   && update-ms-fonts \
   && fc-cache -f
 
@@ -15,11 +14,12 @@ RUN  apk add --update curl openjpeg-tools ruby msttcorefonts-installer fontconfi
 RUN curl -OL "http://pinto.c7a.ca/deploy/jai-1_1_2_01-lib-linux-i586.tar.gz" \
   && tar -xvzpf jai-1_1_2_01-lib-linux-i586.tar.gz
 
-ENV JAIHOME /tmp/jai-1_1_2_01/lib
-ENV CLASSPATH $JAIHOME/jai_core.jar:$JAIHOME/jai_codec.jar:$JAIHOME/mlibwrapper_jai.jar:$CLASSPATH
-ENV LD_LIBRARY_PATH .:$JAIHOME:$CLASSPATH
+ENV JAIHOME=/tmp/jai-1_1_2_01/lib \
+  CLASSPATH=$JAIHOME/jai_core.jar:$JAIHOME/jai_codec.jar:$JAIHOME/mlibwrapper_jai.jar:$CLASSPATH \
+  LD_LIBRARY_PATH=.:$JAIHOME:$CLASSPATH \
+  GEM_HOME=/tmp/gems
 
-RUN  curl -OL "https://github.com/medusa-project/cantaloupe/releases/download/v$VERSION/Cantaloupe-$VERSION.zip" \
+RUN curl -OL "https://github.com/medusa-project/cantaloupe/releases/download/v$VERSION/Cantaloupe-$VERSION.zip" \
   && mkdir -p /usr/local/ \
   && cd /usr/local \
   && unzip /tmp/Cantaloupe-$VERSION.zip \
@@ -27,22 +27,19 @@ RUN  curl -OL "https://github.com/medusa-project/cantaloupe/releases/download/v$
   && rm -rf /tmp/Cantaloupe-$VERSION \
   && rm /tmp/Cantaloupe-$VERSION.zip
 
-RUN adduser -S cantaloupe
+RUN addgroup -S cantaloupe && adduser -S cantaloupe -G cantaloupe
+COPY --chown=cantaloupe:cantaloupe cantaloupe.properties delegates.rb /etc/
 
-COPY cantaloupe.properties delegates.rb config.json /etc/
-RUN  mkdir -p /var/log/cantaloupe \
+RUN mkdir -p /var/log/cantaloupe \
   && mkdir -p /var/cache/cantaloupe \
-  && chown -R cantaloupe /var/log/cantaloupe \
-  && chown -R cantaloupe /var/cache/cantaloupe \
-  && chown cantaloupe /etc/cantaloupe.properties \
-  && chown cantaloupe /etc/delegates.rb \
-  && chown cantaloupe /etc/config.json
+  && chown -R cantaloupe:cantaloupe /var/log/cantaloupe \
+  && chown -R cantaloupe:cantaloupe /var/cache/cantaloupe
 
 USER cantaloupe
 
-RUN  gem install --no-document --install-dir /tmp/gems jwt json_pure
+RUN gem install --no-document --install-dir /tmp/gems jwt json_pure
 
-ENV GEM_HOME /tmp/gems
+EXPOSE 8182
 
 CMD ["sh", "-c", "java -Dcantaloupe.config=/etc/cantaloupe.properties -Dcom.sun.media.jai.disableMediaLib=true -Xmx16g -jar /usr/local/cantaloupe/cantaloupe-$VERSION.war"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,5 +42,5 @@ RUN gem install --no-document --install-dir /tmp/gems jwt json_pure
 
 EXPOSE 8182
 
-CMD ["sh", "-c", "java -Dcantaloupe.config=/etc/cantaloupe.properties -Dcom.sun.media.jai.disableMediaLib=true -Xmx16g -jar /usr/local/cantaloupe/cantaloupe-$VERSION.war"]
+CMD ["sh", "-c", "java -Dcantaloupe.config=/etc/cantaloupe.properties -Dcom.sun.media.jai.disableMediaLib=true -jar /usr/local/cantaloupe/cantaloupe-$VERSION.war"]
 

--- a/README.md
+++ b/README.md
@@ -4,15 +4,10 @@
 
 ## configuration
 
-`cihm-cantaloupe`'s configuration expects `config.json` to exist in the root directory of this repository, with the following properties set:
-
-      {
-        "repositoryBase": "/path/to/repositories"
-        "secrets": {"key": "secret"}
-      }
+Expected environment variables can be found in `docker-compose.yml`.
 
 ## Usage
 
       $ docker-compose up --build
 
-Sets up an instance of Cantaloupe on localhost, port 8182. Note that environment variable VERSION allows you to set the version of Cantaloupe you wish to install.
+Sets up an instance of Cantaloupe on localhost, port 8182.

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -1,0 +1,20 @@
+FROM httpd:2.4.41
+
+RUN sed -i \
+    -e 's/^#\(Include .*vhosts.conf\)/\1/' \
+    -e 's/^#\(Include .*httpd-mpm.conf\)/\1/' \
+    -e 's/^#\(LoadModule .*mod_proxy.so\)/\1/' \
+    -e 's/^#\(LoadModule .*mod_proxy_http.so\)/\1/' \
+    -e 's/^#\(LoadModule .*mod_proxy_html.so\)/\1/' \
+    -e 's/^#\(LoadModule .*mod_xml2enc.so\)/\1/' \
+    -e 's/^#\(LoadModule .*mod_rewrite.so\)/\1/' \
+    -e 's/^#\(LoadModule .*mod_allowmethods.so\)/\1/' \
+    conf/httpd.conf ; \
+    sed -i \
+    -e 's/logs\/httpd.pid/httpd.pid/' \
+    conf/extra/httpd-mpm.conf
+
+ENV CIHM_CANTALOUPE cantaloupe:8182
+
+COPY httpd-vhosts.conf /usr/local/apache2/conf/extra/
+EXPOSE 80

--- a/apache/httpd-vhosts.conf
+++ b/apache/httpd-vhosts.conf
@@ -24,12 +24,8 @@ ServerName canadiana.ca
   RewriteRule .* - [E=host:%{HTTP_HOST}]
   ProxyPassInterpolateEnv On
 
-  ProxyPass /auth http://cookie-authorizer:3000/auth nocanon
-  ProxyPassReverse /auth http://cookie-authorizer:3000/auth
-  ProxyPassReverseCookieDomain cookie-authorizer:3000 ${host} interpolate
-
-  ProxyPass / http://${CIHM_CANTALOUPE}/ nocanon
-  ProxyPassReverse / http://${CIHM_CANTALOUPE}/
+  ProxyPass / http://${CIHM_CANTALOUPE}/ nocanon interpolate
+  ProxyPassReverse / http://${CIHM_CANTALOUPE}/ interpolate
   ProxyPassReverseCookieDomain ${CIHM_CANTALOUPE} ${host} interpolate
   ProxyPreserveHost on
 

--- a/apache/httpd-vhosts.conf
+++ b/apache/httpd-vhosts.conf
@@ -1,0 +1,36 @@
+# Set globally to supress warning message
+ServerName canadiana.ca
+
+# Default server to send everything to Cantaloupe
+<VirtualHost *:80>
+  # X-Forwarded-Host will be set automatically by the web server.
+  RequestHeader set X-Forwarded-Proto HTTP
+  RequestHeader set X-Forwarded-Port 80
+  RequestHeader set X-Forwarded-Path /
+
+
+  AllowEncodedSlashes NoDecode
+  ProxyPassReverseCookiePath / /
+
+#  Allow JavaScript requests against this server
+  Header set Access-Control-Allow-Origin "*"
+
+  ErrorLog logs/image-error.log
+  CustomLog logs//image-access.log combined
+
+  # Use Mod-Rewrite to copy %{HTTP_HOST} into
+  # an Apache environment variable called "host"
+  RewriteEngine On
+  RewriteRule .* - [E=host:%{HTTP_HOST}]
+  ProxyPassInterpolateEnv On
+
+  ProxyPass /auth http://cookie-authorizer:3000/auth nocanon
+  ProxyPassReverse /auth http://cookie-authorizer:3000/auth
+  ProxyPassReverseCookieDomain cookie-authorizer:3000 ${host} interpolate
+
+  ProxyPass / http://${CIHM_CANTALOUPE}/ nocanon
+  ProxyPassReverse / http://${CIHM_CANTALOUPE}/
+  ProxyPassReverseCookieDomain ${CIHM_CANTALOUPE} ${host} interpolate
+  ProxyPreserveHost on
+
+</VirtualHost>

--- a/cantaloupe.properties
+++ b/cantaloupe.properties
@@ -40,6 +40,9 @@ slash_substitute =
 # response. Set to 0 for no maximum.
 max_pixels = 400000000
 
+# Maximum scale to allow (1.0 = full scale; 0 = no maximum).
+max_scale = 1.0
+
 # Errors will also be logged to the error log (if enabled).
 print_stack_trace_on_error_pages = true
 
@@ -64,12 +67,10 @@ delegate_script.cache.enabled = true
 # ENDPOINTS
 ###########################################################################
 
-# !! Configures HTTP Basic authentication in all public endpoints.
-endpoint.public.auth.basic.enabled = false
-endpoint.public.auth.basic.username = myself
-endpoint.public.auth.basic.secret = mypassword
-
+# Enables the IIIF Image API 1.x endpoint, at /iiif/1.
 endpoint.iiif.1.enabled = false
+
+# Enables the IIIF Image API 2.x endpoint, at /iiif/2.
 endpoint.iiif.2.enabled = true
 
 # Controls the response Content-Disposition header for images. Allowed
@@ -106,20 +107,56 @@ endpoint.api.secret =
 
 # Uses one source for all requests. Available values are `FilesystemSource`,
 # `HttpSource`, `JdbcSource`, `S3Source`, and `AzureStorageSource`.
-source.static = FilesystemSource
+source.static = S3Source
 
 # If true, `source.static` will be overridden, and the `source()` delegate
 # method will be used to select a source per-request.
 source.delegate = false
 
 #----------------------------------------
-# FilesystemSource
+# S3Source
 #----------------------------------------
 
-# How to look up files. Allowed values are `BasicLookupStrategy` and
-# `ScriptLookupStrategy`. ScriptLookupStrategy uses the delegate script for
+# !! Endpoint URI.
+# For AWS endpoints, see:
+# https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
+S3Source.endpoint = environment_variable
+
+# !! Credentials for your AWS account.
+# See: http://aws.amazon.com/security-credentials
+# Note that this info can be obtained from elsewhere rather than setting
+# it here; see the user manual.
+S3Source.access_key_id = environment_variable
+S3Source.secret_key = environment_variable
+
+# How to look up objects. Allowed values are `BasicLookupStrategy` and
+# `ScriptLookupStrategy`. ScriptLookupStrategy uses a delegate method for
 # dynamic lookups; see the user manual.
-FilesystemSource.lookup_strategy = ScriptLookupStrategy
+S3Source.lookup_strategy = BasicLookupStrategy
+
+# !! Name of the bucket containing images to be served.
+S3Source.BasicLookupStrategy.bucket.name = environment_variable
+
+# Path within the bucket that will be prefixed to the identifier in the URL.
+# Trailing slash is important!
+S3Source.BasicLookupStrategy.path_prefix =
+
+# Path or extension that will be suffixed to the identifier in the URL.
+S3Source.BasicLookupStrategy.path_suffix =
+
+# Read data in chunks when it may be more efficient. (This also may end up
+# being less efficient, depending on many variables; see the user manual.)
+S3Source.chunking.enabled = true
+
+# Chunk size.
+S3Source.chunking.chunk_size = 512K
+
+# The per-request chunk cache caches downloaded chunks in memory during
+# a request, and clears them when the request is complete.
+S3Source.chunking.cache.enabled = true
+
+# Max per-request chunk cache size.
+S3Source.chunking.cache.max_size = 5M
 
 ###########################################################################
 # PROCESSORS
@@ -129,30 +166,37 @@ FilesystemSource.lookup_strategy = ScriptLookupStrategy
 # Processor Selection
 #----------------------------------------
 
+# * If set to `AutomaticSelectionStrategy`, a "best" available processor
+#   will be selected per-request based on formats and installed
+#   dependencies.
+# * If set to `ManualSelectionStrategy`, a processor will be chosen based
+#   on the rest of the keys in this section.
+processor.selection_strategy = ManualSelectionStrategy
+
 # Image processors to use for various source formats. Available values are
 # `Java2dProcessor`, `GraphicsMagickProcessor`, `ImageMagickProcessor`,
 # `KakaduProcessor`, `OpenJpegProcessor`, `JaiProcessor`, `PdfBoxProcessor`,
 # and `FfmpegProcessor`.
 
 # These extension-specific definitions are optional.
-processor.avi = FfmpegProcessor
-processor.bmp =
-processor.dcm =
-processor.flv = FfmpegProcessor
-processor.gif =
-processor.jp2 = OpenJpegProcessor
-processor.jpg =
-processor.mov = FfmpegProcessor
-processor.mp4 = FfmpegProcessor
-processor.mpg = FfmpegProcessor
-processor.pdf = PdfBoxProcessor
-processor.png =
-processor.tif = JaiProcessor
-processor.webm = FfmpegProcessor
-processor.webp = ImageMagickProcessor
+processor.ManualSelectionStrategy.avi = FfmpegProcessor
+processor.ManualSelectionStrategy.bmp =
+processor.ManualSelectionStrategy.dcm =
+processor.ManualSelectionStrategy.flv = FfmpegProcessor
+processor.ManualSelectionStrategy.gif =
+processor.ManualSelectionStrategy.jp2 = OpenJpegProcessor
+processor.ManualSelectionStrategy.jpg =
+processor.ManualSelectionStrategy.mov = FfmpegProcessor
+processor.ManualSelectionStrategy.mp4 = FfmpegProcessor
+processor.ManualSelectionStrategy.mpg = FfmpegProcessor
+processor.ManualSelectionStrategy.pdf = PdfBoxProcessor
+processor.ManualSelectionStrategy.png =
+processor.ManualSelectionStrategy.tif = JaiProcessor
+processor.ManualSelectionStrategy.webm = FfmpegProcessor
+processor.ManualSelectionStrategy.webp =
 
 # Fall back to this processor for any formats not assigned above.
-processor.fallback = Java2dProcessor
+processor.ManualSelectionStrategy.fallback = Java2dProcessor
 
 #----------------------------------------
 # Global Processor Configuration
@@ -177,10 +221,6 @@ processor.fallback_retrieval_strategy = CacheStrategy
 # Resolution of vector rasterization (of e.g. PDFs) at a scale of 1.
 processor.dpi = 150
 
-# Expands contrast to utilize available dynamic range. This forces the entire
-# source image to be read into memory, so can be slow with large images.
-processor.normalize = false
-
 # Color of the background when an image is rotated or alpha-flattened, for
 # output formats that don't support transparency.
 # This may not be respected for indexed color derivative images.
@@ -201,11 +241,6 @@ processor.metadata.preserve = false
 # Whether to auto-rotate images using the EXIF `Orientation` field.
 # The check for this field can impair performance slightly.
 processor.metadata.respect_orientation = false
-
-# Whether to reduce images with more than 8 bits per sample to 8 bits.
-# This only applies to formats that support >8-bit samples, and not all
-# processors respect this setting; see the user manual.
-processor.limit_to_8_bits = true
 
 # Progressive JPEGs are usually more compact.
 processor.jpg.progressive = true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,10 +3,13 @@ version: "3"
 services:
   cihm-cantaloupe:
     build: .
-    environment:
-      - REPOSITORY_BASE
     image: cihm-cantaloupe:latest
     ports:
       - "8182:8182"
-    volumes:
-      - /repository:/repository
+    # environment:
+    # - S3SOURCE_ENDPOINT=https://swifts3.endpoint/
+    # - S3SOURCE_ACCESS_KEY_ID=swiftuser
+    # - S3SOURCE_SECRET_KEY=swifts3secret
+    # - S3SOURCE_BASICLOOKUPSTRATEGY_BUCKET_NAME=test
+    # - JWT_ISSUER=CAP
+    # - JWT_SECRET=capjwtsecret

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,6 @@ services:
       CIHM_CANTALOUPE: 'cantaloupe:8182'
     depends_on:
       - cantaloupe
-      - cookie-authorizer
     ports:
       - "80:80"
   cantaloupe:
@@ -23,7 +22,3 @@ services:
     # - S3SOURCE_BASICLOOKUPSTRATEGY_BUCKET_NAME=test
     # - JWT_ISSUER=CAP
     # - JWT_SECRET=capjwtsecret
-  cookie-authorizer:
-    build: cihm-cookie-authorizer/
-    image: cihm-cookie-authorizer
-    command: yarn run start

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,21 @@
 version: "3"
 
 services:
-  cihm-cantaloupe:
-    build: .
-    image: cihm-cantaloupe:latest
+  cantaloupe-apache:
+    build: apache/
+    image: cantaloupe-apache
+    environment:
+      CIHM_CANTALOUPE: 'cantaloupe:8182'
+    depends_on:
+      - cantaloupe
+      - cookie-authorizer
     ports:
-      - "8182:8182"
+      - "80:80"
+  cantaloupe:
+    build: .
+    image: cihm-cantaloupe
+    #ports:
+    #  - "8182:8182"
     # environment:
     # - S3SOURCE_ENDPOINT=https://swifts3.endpoint/
     # - S3SOURCE_ACCESS_KEY_ID=swiftuser
@@ -13,3 +23,7 @@ services:
     # - S3SOURCE_BASICLOOKUPSTRATEGY_BUCKET_NAME=test
     # - JWT_ISSUER=CAP
     # - JWT_SECRET=capjwtsecret
+  cookie-authorizer:
+    build: cihm-cookie-authorizer/
+    image: cihm-cookie-authorizer
+    command: yarn run start


### PR DESCRIPTION
Upgrades Cantaloupe to 4.1.2; uses S3Source to find images; uses BasicLookupStrategy to look images up (since we no longer need to hash on paths).