### PR TITLE
Unified ZFS/Swift-compatible Cantaloupe config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # this file is an edited version of https://github.com/kaij/cantaloupe/blob/docker-deploy/docker/Dockerfile
 
-FROM alpine:3.12.0
+FROM alpine:3.12.1
 
 WORKDIR /tmp
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 
 ## configuration
 
-Expected environment variables can be found in `docker-compose.yml`.
+Expected environment variables can be found in `docker-compose.yml`. Note the use of the `SOURCE_STATIC` variable to choose between `S3Source` (for Swift) and `FilesystemSource` (for ZFS).
 
 ## Usage
 
       $ docker-compose up --build
 
-Sets up an instance of Cantaloupe and Apache, listening on *:80.
+Sets up an instance of Cantaloupe and Apache, listening on \*:80.

--- a/cantaloupe.properties
+++ b/cantaloupe.properties
@@ -114,6 +114,16 @@ source.static = environment_variable
 source.delegate = false
 
 #----------------------------------------
+# FilesystemSource
+#----------------------------------------
+
+# How to look up files. Allowed values are `BasicLookupStrategy` and
+# `ScriptLookupStrategy`. ScriptLookupStrategy uses the delegate script for
+# dynamic lookups; see the user manual.
+FilesystemSource.lookup_strategy = ScriptLookupStrategy
+
+
+#----------------------------------------
 # S3Source
 #----------------------------------------
 

--- a/cantaloupe.properties
+++ b/cantaloupe.properties
@@ -107,7 +107,7 @@ endpoint.api.secret =
 
 # Uses one source for all requests. Available values are `FilesystemSource`,
 # `HttpSource`, `JdbcSource`, `S3Source`, and `AzureStorageSource`.
-source.static = S3Source
+source.static = environment_variable
 
 # If true, `source.static` will be overridden, and the `source()` delegate
 # method will be used to select a source per-request.

--- a/delegates.rb
+++ b/delegates.rb
@@ -117,7 +117,13 @@ class CustomDelegate
   def filesystemsource_pathname(options = {})
     repository_base = ENV["REPOSITORY_BASE"]
     repository_list = Dir.entries(repository_base).grep_v(/^\.*$/)
-    aip, partpath = CGI::unescape(context["identifier"]).split('/', 2)
+    canvas = self.canvas
+    if canvas
+      pathname = canvas["master"]["path"]
+    else
+      pathname = context["identifier"]
+    end
+    aip, partpath = CGI::unescape(pathname).split('/', 2)
     depositor = aip.split('.')[0]
     aip_hash = Zlib::crc32(aip).to_s[-3..-1]
     aip_path = nil;

--- a/delegates.rb
+++ b/delegates.rb
@@ -5,6 +5,7 @@
 require 'cgi'
 require 'jwt'
 require 'json'
+require 'zlib'
 require 'net/http'
 
 class CustomDelegate
@@ -108,13 +109,28 @@ class CustomDelegate
   end
 
   def source(options = {})
-    return "FilesystemSource"
   end
 
   def azurestoragesource_blob_key(options = {})
   end
 
   def filesystemsource_pathname(options = {})
+    repository_base = ENV["REPOSITORY_BASE"]
+    repository_list = Dir.entries(repository_base).grep_v(/^\.*$/)
+    aip, partpath = CGI::unescape(context["identifier"]).split('/', 2)
+    depositor = aip.split('.')[0]
+    aip_hash = Zlib::crc32(aip).to_s[-3..-1]
+    aip_path = nil;
+    repository_list.each do |path|
+      testpath = [repository_base, path, depositor, aip_hash, aip].join("/")
+      if File.directory?(testpath)
+        aip_path = testpath
+        break
+      end
+    end
+    return nil unless aip_path
+    # Note: For anything beyond a test script, don't trust 'partpath' (check for ../)
+    return [aip_path, partpath].join("/")
   end
 
   def httpsource_resource_info(options = {})

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,9 @@ services:
     #ports:
     #  - "8182:8182"
     # environment:
+    # - SOURCE_STATIC=S3Source (for Swift)
+    # - SOURCE_STATIC=FilesystemSource (for ZFS)
+    # - REPOSITORY_BASE=/path/to/repository (for ZFS)
     # - S3SOURCE_ENDPOINT=https://swifts3.endpoint/
     # - S3SOURCE_ACCESS_KEY_ID=swiftuser
     # - S3SOURCE_SECRET_KEY=swifts3secret


### PR DESCRIPTION
This should let us use the same Cantaloupe image for ZFS and Swift.

I haven't been able to test ZFS yet, but Swift appears to work.