### PR TITLE
Update Cantaloupe delegates script to handle `extension` field for `canvas` documents.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN wget -nv "https://github.com/medusa-project/cantaloupe/releases/download/v$V
   && chown -R cantaloupe:cantaloupe /var/log/cantaloupe \
   && chown -R cantaloupe:cantaloupe /var/cache/cantaloupe
 
-COPY --chown=cantaloupe:cantaloupe cantaloupe.properties delegates.rb /etc/
+COPY --chown=cantaloupe:cantaloupe cantaloupe.properties delegates.rb test.rb /etc/
 
 USER cantaloupe
 

--- a/delegates.rb
+++ b/delegates.rb
@@ -77,8 +77,6 @@ class CustomDelegate
 
   def authorize(options = {})
     canvas = self.canvas
-    puts "authorize() Canvas: " + JSON.generate(canvas)
-
     if (canvas && !canvas["takedown"])
       return true
     else
@@ -121,8 +119,10 @@ class CustomDelegate
     repository_list = Dir.entries(repository_base).grep_v(/^\.*$/)
     canvas = self.canvas
 
-    puts "filesystemsource_pathname() Canvas: " + JSON.generate(canvas)
     if canvas
+      # TODO: Do we want to bother supporting ZFS filesystem any more?
+      # access-files Swift container may have different images...
+      # should we be looking at canvas["source"]["path"] ?
       pathname = canvas["master"]["path"]
     else
       pathname = context["identifier"]
@@ -158,19 +158,18 @@ class CustomDelegate
   def s3source_object_info(options = {})
     rv = { "bucket" => ENV["S3SOURCE_BASICLOOKUPSTRATEGY_BUCKET_NAME"] }
     canvas = self.canvas
-    puts "s3source_object_info() Canvas: " + JSON.generate(canvas)
     if canvas
       extension = canvas["master"]["extension"]
       if extension
         rv["key"] = context["identifier"]+"."+extension
         rv["bucket"] = ENV["S3SOURCE_ACCESSFILES_BUCKET_NAME"]
       else
+        # Assuming one of the two must exist
         rv["key"] = canvas["master"]["path"]
       end
     else
       rv["key"] = context["identifier"]
     end
-    puts "s3source_object_info() rv: " + JSON.generate(rv)
     return rv
   end
 

--- a/delegates.rb
+++ b/delegates.rb
@@ -77,6 +77,8 @@ class CustomDelegate
 
   def authorize(options = {})
     canvas = self.canvas
+    puts "Canvas: " + JSON.generate(canvas)
+
     if (canvas && !canvas["takedown"])
       return true
     else

--- a/delegates.rb
+++ b/delegates.rb
@@ -118,7 +118,6 @@ class CustomDelegate
     repository_base = ENV["REPOSITORY_BASE"]
     repository_list = Dir.entries(repository_base).grep_v(/^\.*$/)
     canvas = self.canvas
-
     if canvas
       # TODO: Do we want to bother supporting ZFS filesystem any more?
       # access-files Swift container may have different images...

--- a/delegates.rb
+++ b/delegates.rb
@@ -77,7 +77,7 @@ class CustomDelegate
 
   def authorize(options = {})
     canvas = self.canvas
-    puts "Canvas: " + JSON.generate(canvas)
+    puts "authorize() Canvas: " + JSON.generate(canvas)
 
     if (canvas && !canvas["takedown"])
       return true
@@ -120,6 +120,8 @@ class CustomDelegate
     repository_base = ENV["REPOSITORY_BASE"]
     repository_list = Dir.entries(repository_base).grep_v(/^\.*$/)
     canvas = self.canvas
+
+    puts "filesystemsource_pathname() Canvas: " + JSON.generate(canvas)
     if canvas
       pathname = canvas["master"]["path"]
     else
@@ -156,11 +158,19 @@ class CustomDelegate
   def s3source_object_info(options = {})
     rv = { "bucket" => ENV["S3SOURCE_BASICLOOKUPSTRATEGY_BUCKET_NAME"] }
     canvas = self.canvas
+    puts "s3source_object_info() Canvas: " + JSON.generate(canvas)
     if canvas
-      rv["key"] = canvas["master"]["path"]
+      extension = canvas["master"]["extension"]
+      if extension
+        rv["key"] = context["identifier"]+"."+extension
+        rv["bucket"] = ENV["S3SOURCE_ACCESSFILES_BUCKET_NAME"]
+      else
+        rv["key"] = canvas["master"]["path"]
+      end
     else
       rv["key"] = context["identifier"]
     end
+    puts "s3source_object_info() rv: " + JSON.generate(rv)
     return rv
   end
 

--- a/delegates.rb
+++ b/delegates.rb
@@ -160,7 +160,7 @@ class CustomDelegate
     if canvas
       extension = canvas["master"]["extension"]
       if extension
-        rv["key"] = context["identifier"]+"."+extension
+        rv["key"] = context["identifier"] + "." + extension
         rv["bucket"] = ENV["S3SOURCE_ACCESSFILES_BUCKET_NAME"]
       else
         # Assuming one of the two must exist

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
     # - S3SOURCE_ACCESS_KEY_ID=swiftuser
     # - S3SOURCE_SECRET_KEY=swifts3secret
     # - S3SOURCE_BASICLOOKUPSTRATEGY_BUCKET_NAME=test
+    # - S3SOURCE_ACCESSFILES_BUCKET_NAME: test-access-files
     # - CANVAS_DB=http://couch.domain/canvas (do not add a trailing slash)
     # - CAP_JWT_SECRET=capjwtsecret
     # - AUTH_JWT_SECRET=authjwtsecret

--- a/test.rb
+++ b/test.rb
@@ -1,0 +1,11 @@
+# This file is named `test.rb`, in the same folder as `delegates.rb`
+# See https://cantaloupe-project.github.io/manual/4.0/delegate-script.html#Testing%20Delegate%20Methods for more
+require './delegates'
+
+obj = CustomDelegate.new
+obj.context = {
+  'identifier' => '69429/c0nz80n18k93',
+  'client_ip' => '127.0.0.1',
+}
+
+puts JSON.generate(obj.canvas)


### PR DESCRIPTION
This is the (first?) PR for https://github.com/crkn-rcdr/Access-Platform/issues/137